### PR TITLE
Enable pausing and seeking from lyrics

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -3150,6 +3150,7 @@ static void toggle_playlist_full_paths (void)
 static void menu_key (const struct iface_key *k)
 {
     enum key_cmd cmd = get_key_cmd (CON_MENU, k);
+
 	if (iface_in_help ())
 		iface_handle_help_key (k);
 	else if (iface_in_lyrics ()
@@ -3166,8 +3167,6 @@ static void menu_key (const struct iface_key *k)
 	else if (iface_in_theme_menu ())
 		theme_menu_key (k);
 	else if (!iface_key_is_resize (k)) {
-		/* enum key_cmd cmd = get_key_cmd (CON_MENU, k); */
-
 		switch (cmd) {
 			case KEY_CMD_QUIT_CLIENT:
 				want_quit = QUIT_CLIENT;

--- a/interface.c
+++ b/interface.c
@@ -3149,16 +3149,24 @@ static void toggle_playlist_full_paths (void)
 /* Handle key. */
 static void menu_key (const struct iface_key *k)
 {
+    enum key_cmd cmd = get_key_cmd (CON_MENU, k);
 	if (iface_in_help ())
 		iface_handle_help_key (k);
-	else if (iface_in_lyrics ())
+	else if (iface_in_lyrics ()
+        && cmd != KEY_CMD_STOP         
+        && cmd != KEY_CMD_PAUSE         
+        && cmd != KEY_CMD_SEEK_FORWARD         
+        && cmd != KEY_CMD_SEEK_BACKWARD
+        && cmd != KEY_CMD_SEEK_FORWARD_5
+        && cmd != KEY_CMD_SEEK_BACKWARD_5
+    )
 		iface_handle_lyrics_key (k);
 	else if (iface_in_entry ())
 		entry_key (k);
 	else if (iface_in_theme_menu ())
 		theme_menu_key (k);
 	else if (!iface_key_is_resize (k)) {
-		enum key_cmd cmd = get_key_cmd (CON_MENU, k);
+		/* enum key_cmd cmd = get_key_cmd (CON_MENU, k); */
 
 		switch (cmd) {
 			case KEY_CMD_QUIT_CLIENT:

--- a/lyrics.c
+++ b/lyrics.c
@@ -80,10 +80,13 @@ lists_t_strs *lyrics_load_file (const char *filename)
 	return result;
 }
 
-/* Given an audio's file name, load lyrics from the default lyrics file name. */
+/* Given an audio's file name, load lyrics from the default lyrics file name. 
+ * Also try with .txt extension if extensionless file not found.
+ */
 void lyrics_autoload (const char *filename)
 {
 	char *lyrics_filename, *extn;
+	char *lyrics_filename_dottxt;
 
 	assert (!raw_lyrics);
 	assert (lyrics_message);
@@ -107,7 +110,15 @@ void lyrics_autoload (const char *filename)
 	extn = ext_pos (lyrics_filename);
 	if (extn) {
 		*--extn = '\0';
-		raw_lyrics = lyrics_load_file (lyrics_filename);
+        if (file_exists(lyrics_filename)) {
+            raw_lyrics = lyrics_load_file (lyrics_filename);
+        }
+        else {
+            lyrics_filename = xrealloc(lyrics_filename, strlen(lyrics_filename) + 5);
+            extn = lyrics_filename + strlen(lyrics_filename) - 1;
+            strcpy(lyrics_filename + strlen(lyrics_filename), ".txt");
+            raw_lyrics = lyrics_load_file (lyrics_filename);
+        }
 	}
 	else
 		lyrics_message = "[No lyrics file!]";


### PR DESCRIPTION
Hi, I propose this slight modification where:

1. Can press space and seek forward/backward from the lyrics screen. 
> This allows for example to put the transcript of a podcast in the lyrics file and to study it (useful to learn foreign languages for instance). At the moment, any key will just go back to the explorer, making the lyrics screen disappear.
2. Whenever the extensionless file for lyrics is not found, also look in a .txt file. 
> This should be no problem because .txt files are not used for sound or music, also some people might prefer this convention.
Let me know what you think, thanks.