### PR TITLE
Added entry in line 259 activate *.tak files support.

### DIFF
--- a/decoder_plugins/ffmpeg/ffmpeg.c
+++ b/decoder_plugins/ffmpeg/ffmpeg.c
@@ -256,6 +256,7 @@ static void load_audio_extns (lists_t_strs *list)
 		{"ra", "rm"},
 		{"sap", "libgme"},
 		{"spc", "libgme"},
+		{"tak", "tak"},
 		{"tta", "tta"},
 		{"vgm", "libgme"},
 		{"vgz", "libgme"},


### PR DESCRIPTION
It should be already there, since FFmpeg supports TAK's audio and it's already a while.

I use MOC currently since months with this mod. Tested with hundreds of files. There's small inaccuracy while seeking, but besides it just works as it should. I like to share it with others, as Tom's Audio Codec seems to be one if not the best lossless audio codec, we have now. Because there lack players supporting *.tak files, the more I'll be happy to see my favorite player supporting it out of box.

It's my very first ever commit, so I ask for understanding.