### PR TITLE
add https to is_url

### DIFF
--- a/files.c
+++ b/files.c
@@ -85,6 +85,7 @@ void files_cleanup ()
 inline int is_url (const char *str)
 {
 	return !strncasecmp (str, "http://", sizeof ("http://") - 1)
+		|| !strncasecmp (str, "https://", sizeof ("https://") - 1)
 		|| !strncasecmp (str, "ftp://", sizeof ("ftp://") - 1);
 }
 


### PR DESCRIPTION
Streaming servers rarely have confidential information, but "https always" is getting popular.
Could use a follow-up patch to allow insecure https connections, but that's less important since it's solving someone else's mistakes.